### PR TITLE
Attempt to account for setup time admin on edit page

### DIFF
--- a/assets/js/backend.js
+++ b/assets/js/backend.js
@@ -151,7 +151,7 @@ jQuery(function($) {
 
 			if (itemData) {
 				itemData.forEach(function(item, idx) {
-					items.push(new Item(item[0], item[1], item[2], idx + 1));
+					items.push(new Item(item[0], item[1], item[2], item[3], idx + 1));
 				});
 			}
 

--- a/assets/js/src/Item.js
+++ b/assets/js/src/Item.js
@@ -1,10 +1,11 @@
-function Item(id, length, columns, pos) {
+function Item(id, length, columns, setup, pos) {
 	var self = this;
 
 	// setup simple data properties
 
 	self.id         = ko.observable(id);
 	self.length     = ko.observable(length);
+	self.setup      = ko.observable(setup);
 	self.scheduled  = ko.observable();      // will be set by calculateSchedule()
 	self.dateSwitch = ko.observable(false); // will be set by calculateSchedule()
 
@@ -82,6 +83,11 @@ function Item(id, length, columns, pos) {
 		viewModel.calculateSchedule(0);
 	});
 
+	self.setup.subscribe(function(newValue) {
+		self.sync({setup: newValue});
+		viewModel.calculateSchedule(0);
+	});
+
 	scheduleColumns.forEach(function(colID) {
 		var name = 'col_' + colID;
 
@@ -141,6 +147,7 @@ function Item(id, length, columns, pos) {
 
 				self.id(result.data.id);
 				self.length(result.data.length);
+				self.setup(result.data.setup);
 				self.errors(false);
 
 				scheduleColumns.forEach(function(id) {

--- a/assets/js/src/ItemsViewModel.js
+++ b/assets/js/src/ItemsViewModel.js
@@ -42,7 +42,7 @@ function ItemsViewModel(items) {
 			start = scheduleStart.getTime();
 		}
 		else {
-			start = items[startIdx].scheduled() + (items[startIdx].length() * 1000);
+			start = items[startIdx].scheduled() + ((items[startIdx].length() + items[startIdx].setup()) * 1000);
 		}
 
 		scheduled = start;
@@ -56,7 +56,7 @@ function ItemsViewModel(items) {
 
 			date       = moment.unix(scheduled / 1000).utcOffset(scheduleTZ);
 			dayOfYear  = date.dayOfYear();
-			scheduled += ((item.length() + scheduleSetupTime) * 1000);
+			scheduled += ((item.length() + item.setup()) * 1000);
 
 			if (prev !== null && prev !== dayOfYear) {
 				item.dateSwitch(date.format('dddd, ll'));
@@ -73,7 +73,7 @@ function ItemsViewModel(items) {
 			data[id] = '';
 		});
 
-		item = new Item(-1, 30*60, data, self.items().length + 1);
+		item = new Item(-1, 30*60, data, scheduleSetupTime, self.items().length + 1);
 		item.sync();
 
 		self.items.push(item);

--- a/src/horaro/Library/Entity/ScheduleItem.php
+++ b/src/horaro/Library/Entity/ScheduleItem.php
@@ -232,11 +232,7 @@ class ScheduleItem {
 		if (!empty($options['setup'])) {
 			try {
 				$parser = new ReadableTime();
-				$parsed = $parser->parse(trim($options['setup']));
-
-				if ($parsed) {
-					return ReadableTime::dateTimeToDateInterval($parsed);
-				}
+				return $parser->parse(trim($options['setup']));
 			}
 			catch (\InvalidArgumentException $e) {
 				// ignore bad user input
@@ -244,6 +240,33 @@ class ScheduleItem {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Get setup time in seconds
+	 *
+	 * @return int
+	 */
+	public function getSetupTimeInSeconds(ScheduleColumn $optionsCol = null) {
+		return ReadableTime::dateTimeToSeconds($this->getSetupTime($optionsCol));
+	}
+
+	/**
+	 * Get setup time as ISO duration
+	 *
+	 * @return string
+	 */
+	public function getSetupTimeISODuration(ScheduleColumn $optionsCol = null) {
+		return ReadableTime::dateTimeToISODuration($this->getSetupTime($optionsCol));
+	}
+
+	/**
+	 * Get setup time as DateInterval
+	 *
+	 * @return \DateInterval
+	 */
+	public function getSetupTimeDateInterval(ScheduleColumn $optionsCol = null) {
+		return ReadableTime::dateTimeToDateInterval($this->getSetupTime($optionsCol));
 	}
 
 	/**

--- a/src/horaro/Library/ScheduleItemIterator.php
+++ b/src/horaro/Library/ScheduleItemIterator.php
@@ -51,7 +51,7 @@ class ScheduleItemIterator implements \Iterator {
 		$setupTime = $this->setup;
 
 		if ($this->optionsCol) {
-			$customSetup = $this->current->getSetupTime($this->optionsCol);
+			$customSetup = $this->current->getSetupTimeDateInterval($this->optionsCol);
 
 			if ($customSetup) {
 				$setupTime = $customSetup;

--- a/src/horaro/WebApp/Controller/ScheduleController.php
+++ b/src/horaro/WebApp/Controller/ScheduleController.php
@@ -13,6 +13,7 @@ namespace horaro\WebApp\Controller;
 use horaro\Library\Entity\Event;
 use horaro\Library\Entity\Schedule;
 use horaro\Library\Entity\ScheduleColumn;
+use horaro\Library\ReadableTime;
 use horaro\WebApp\Exception as Ex;
 use horaro\WebApp\Validator\ScheduleValidator;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,11 +22,16 @@ use Symfony\Component\HttpFoundation\Response;
 class ScheduleController extends BaseController {
 	public function detailAction(Request $request) {
 		$schedule  = $this->getRequestedSchedule($request);
+		$optsCol   = $schedule->getOptionsColumn();
+		$setup     = $schedule->getSetupTime();
 		$items     = [];
 		$columnIDs = [];
 
 		foreach ($schedule->getItems() as $item) {
 			$extra = [];
+			$itemSetup = ($optsCol !== null) ? $item->getSetupTime($optsCol) : null;
+			$itemSetup = ($itemSetup === null) ? $setup : $itemSetup;
+			$itemSetup = ReadableTime::dateTimeToSeconds($itemSetup);
 
 			foreach ($item->getExtra() as $colID => $value) {
 				$extra[$this->encodeID($colID, 'schedule.column')] = $value;
@@ -34,7 +40,8 @@ class ScheduleController extends BaseController {
 			$items[] = [
 				$this->encodeID($item->getId(), 'schedule.item'),
 				$item->getLengthInSeconds(),
-				$extra
+				$extra,
+				$itemSetup
 			];
 		}
 

--- a/src/horaro/WebApp/Controller/ScheduleItemController.php
+++ b/src/horaro/WebApp/Controller/ScheduleItemController.php
@@ -12,6 +12,7 @@ namespace horaro\WebApp\Controller;
 
 use horaro\Library\Entity\Schedule;
 use horaro\Library\Entity\ScheduleItem;
+use horaro\Library\ReadableTime;
 use horaro\WebApp\Exception as Ex;
 use horaro\WebApp\Validator\ScheduleItemValidator;
 use Symfony\Component\HttpFoundation\Request;
@@ -254,12 +255,18 @@ class ScheduleItemController extends BaseController {
 			$extraData[$this->encodeID($colID, 'schedule.column')] = $value;
 		}
 
+		$setupTime = $item->getSetupTime();
+		if ($setupTime === null)
+			$setupTime = $item->getSchedule()->getSetupTime();
+		$setupTime = ReadableTime::dateTimeToSeconds($setupTime);
+
 		return $this->respondWithArray([
 			'data' => [
 				'id'      => $this->encodeID($item->getId(), 'schedule.item'),
 				'pos'     => $item->getPosition(),
 				'length'  => $item->getLengthInSeconds(),
-				'columns' => $extraData
+				'columns' => $extraData,
+				'setup'   => $setupTime
 			]
 		], $status);
 	}


### PR DESCRIPTION
This is NOT tested (yet), since I haven't managed to get a working test instance.
But it is an attempt at accounting for the per-run setup time on the schedule edit page, so the times shown there are accurate again when using the setup-times option column feature.

I'm not sure if I missed any places where it's observing the length, that now also needs to observe the setup time or something like that.